### PR TITLE
Fix gnuplot display issue in Killercoda environment

### DIFF
--- a/lean-basic-of-gnuplot/scenario01/setup.sh
+++ b/lean-basic-of-gnuplot/scenario01/setup.sh
@@ -5,9 +5,20 @@ set -euxo pipefail
 mkdir -p /root/work/data
 cd /root/work
 
-# gnuplotのインストール
+# 必要なパッケージのインストール
 apt-get update
-apt-get install -y gnuplot gnuplot-qt
+apt-get install -y gnuplot apache2
+
+# Webサーバーの設定
+systemctl start apache2
+mkdir -p /var/www/html/plots
+chmod 755 /var/www/html/plots
+
+# gnuplotのデフォルト設定（PNG出力）
+cat > /root/.gnuplot << 'EOF'
+# デフォルトでPNG出力を使用
+set terminal png size 800,600 font "Arial,14"
+EOF
 
 # サンプルデータの準備
 cat > /root/work/data/marathon.dat << 'EOF'
@@ -121,3 +132,5 @@ EOF
 echo "環境のセットアップが完了しました。"
 echo "作業ディレクトリ: /root/work"
 echo "データディレクトリ: /root/work/data"
+echo "Webサーバー: http://localhost/"
+echo "グラフ出力先: /var/www/html/plots/"

--- a/lean-basic-of-gnuplot/scenario01/step1.md
+++ b/lean-basic-of-gnuplot/scenario01/step1.md
@@ -10,38 +10,84 @@
 
 gnuplotが起動すると、対話型のプロンプト `gnuplot>` が表示されます。
 
-## 基本的なプロット
+## Killercoda環境での出力設定
 
-簡単な数学関数をプロットしてみましょう：
+Killercodaはターミナル環境のため、グラフをWeb経由で表示します。まず出力設定を確認しましょう：
+
+`set terminal`{{execute}}
+
+PNG形式で出力するように設定されています。
+
+## 基本的なプロット（画像出力）
+
+簡単な数学関数をプロットして、Webで表示してみましょう：
+
+`set output '/var/www/html/plots/sin_plot.png'`{{execute}}
 
 `plot sin(x)`{{execute}}
 
-正弦波が表示されましたね！gnuplotは数学関数を直接プロットできます。
+`unset output`{{execute}}
 
-複数の関数を同時に表示することもできます：
+グラフが生成されました！以下のリンクで表示できます：
 
-`plot sin(x), cos(x)`{{execute}}
+[正弦波のグラフを表示]({{TRAFFIC_HOST1_80}}/plots/sin_plot.png)
+
+## 複数の関数をプロット
+
+複数の関数を同時に表示してみましょう：
+
+`set output '/var/www/html/plots/sin_cos_plot.png'`{{execute}}
+
+`plot sin(x) title "sin(x)", cos(x) title "cos(x)"`{{execute}}
+
+`unset output`{{execute}}
+
+[正弦波と余弦波のグラフを表示]({{TRAFFIC_HOST1_80}}/plots/sin_cos_plot.png)
+
+## ターミナルでの簡易表示（ASCII）
+
+画像を生成せずに、ターミナルで直接確認することもできます：
+
+`set terminal dumb`{{execute}}
+
+`plot sin(x)`{{execute}}
+
+ASCIIアートでグラフが表示されます！
+
+元の設定に戻します：
+
+`set terminal png size 800,600 font "Arial,14"`{{execute}}
 
 ## プロットのスタイル変更
 
 線のスタイルを変更してみましょう：
 
-`plot sin(x) with lines, cos(x) with points`{{execute}}
+`set output '/var/www/html/plots/style_plot.png'`{{execute}}
 
-- `with lines` - 線でプロット
-- `with points` - 点でプロット
-- `with linespoints` - 線と点の両方でプロット
+`plot sin(x) with lines title "線", cos(x) with points title "点"`{{execute}}
+
+`unset output`{{execute}}
+
+[スタイルの異なるグラフを表示]({{TRAFFIC_HOST1_80}}/plots/style_plot.png)
 
 ## 範囲の指定
 
 x軸の範囲を指定してプロットできます：
 
+`set output '/var/www/html/plots/range_plot.png'`{{execute}}
+
 `plot [-2*pi:2*pi] sin(x) with lines`{{execute}}
+
+`unset output`{{execute}}
+
+[範囲指定したグラフを表示]({{TRAFFIC_HOST1_80}}/plots/range_plot.png)
 
 ## gnuplotの基本コマンド
 
+- `set terminal` - 出力形式の設定
+- `set output` - 出力ファイルの指定
+- `unset output` - 出力ファイルを閉じる
 - `replot` - 前回のプロットを再描画
-- `clear` - 画面をクリア
 - `reset` - すべての設定をリセット
 - `help` - ヘルプの表示
 - `quit` または `exit` - gnuplotを終了

--- a/lean-basic-of-gnuplot/scenario01/step2.md
+++ b/lean-basic-of-gnuplot/scenario01/step2.md
@@ -22,7 +22,17 @@ gnuplotを再起動してデータをプロットします：
 
 `gnuplot`{{execute}}
 
-`plot "data/marathon.dat" using 1:2 with boxes`{{execute}}
+まず、PNG出力を設定します：
+
+`set terminal png size 800,600 font "Arial,14"`{{execute}}
+
+`set output '/var/www/html/plots/marathon_full.png'`{{execute}}
+
+`plot "data/marathon.dat" using 1:2 with boxes title "完走者数"`{{execute}}
+
+`unset output`{{execute}}
+
+[マラソンデータの全体像を表示]({{TRAFFIC_HOST1_80}}/plots/marathon_full.png)
 
 ## データの分析
 
@@ -48,6 +58,40 @@ gnuplotを再起動してデータをプロットします：
 
 範囲を限定して、早い時間帯を詳しく見てみましょう：
 
-`plot [120:250] "data/marathon.dat" using 1:2 with boxes`{{execute}}
+`set output '/var/www/html/plots/marathon_zoom.png'`{{execute}}
 
-このように、**データを可視化することで、数値だけでは見えない重要な情報**を発見できます。
+`set xlabel "完走時間 [分]"`{{execute}}
+
+`set ylabel "ランナー数 [人]"`{{execute}}
+
+`set title "マラソン完走時間分布（120-250分）"`{{execute}}
+
+`plot [120:250] "data/marathon.dat" using 1:2 with boxes lc rgb "blue" title "完走者数"`{{execute}}
+
+`unset output`{{execute}}
+
+[早い時間帯の詳細を表示]({{TRAFFIC_HOST1_80}}/plots/marathon_zoom.png)
+
+## ASCIIでの簡易確認
+
+ターミナルで分布の形を確認することもできます：
+
+`set terminal dumb`{{execute}}
+
+`plot [120:450] "data/marathon.dat" using 1:2 with boxes`{{execute}}
+
+二峰性の分布がASCIIでも確認できますね！
+
+元の設定に戻します：
+
+`set terminal png size 800,600 font "Arial,14"`{{execute}}
+
+## 発見のまとめ
+
+このように、**データを可視化することで、数値だけでは見えない重要な情報**を発見できます：
+
+- 平均値だけでは実態を把握できない
+- 二峰性分布は異なる2つの集団の存在を示唆
+- 適切な準備には分布全体の理解が必要
+
+次のステップでは、別のデータセットを使って予測分析を行います。

--- a/lean-basic-of-gnuplot/scenario01/step3.md
+++ b/lean-basic-of-gnuplot/scenario01/step3.md
@@ -8,7 +8,21 @@
 
 `reset`{{execute}}
 
-`plot "data/runtime.dat" using 1:2 with lines`{{execute}}
+`set terminal png size 800,600 font "Arial,14"`{{execute}}
+
+`set output '/var/www/html/plots/runtime_linear.png'`{{execute}}
+
+`set xlabel "クラスターサイズ"`{{execute}}
+
+`set ylabel "実行時間 [秒]"`{{execute}}
+
+`set title "シミュレーション実行時間"`{{execute}}
+
+`plot "data/runtime.dat" using 1:2 with lines lw 2 title "実測データ"`{{execute}}
+
+`unset output`{{execute}}
+
+[実行時間データ（線形スケール）]({{TRAFFIC_HOST1_80}}/plots/runtime_linear.png)
 
 このグラフでは、クラスターサイズが大きくなるにつれて実行時間が急激に増加していることがわかります。
 
@@ -16,9 +30,21 @@
 
 このような場合、両対数プロットが有効です：
 
+`set output '/var/www/html/plots/runtime_loglog.png'`{{execute}}
+
 `set logscale`{{execute}}
 
-`plot "data/runtime.dat" using 1:2 with lines`{{execute}}
+`set xlabel "クラスターサイズ"`{{execute}}
+
+`set ylabel "実行時間 [秒]"`{{execute}}
+
+`set title "シミュレーション実行時間（両対数プロット）"`{{execute}}
+
+`plot "data/runtime.dat" using 1:2 with points pt 7 ps 1 title "実測データ"`{{execute}}
+
+`unset output`{{execute}}
+
+[実行時間データ（両対数スケール）]({{TRAFFIC_HOST1_80}}/plots/runtime_loglog.png)
 
 両対数プロットで直線になることから、実行時間がべき乗則に従うことがわかります。
 
@@ -26,8 +52,16 @@
 
 データがべき乗則 T ~ N^k に従うと仮定して、モデルと比較してみましょう：
 
-`plot "data/runtime.dat" using 1:2 title "実測データ" with points, \
-(x/2500)**3 title "モデル: T = (N/2500)^3"`{{execute}}
+`set output '/var/www/html/plots/runtime_model.png'`{{execute}}
+
+`set title "実行時間：データとモデルの比較"`{{execute}}
+
+`plot "data/runtime.dat" using 1:2 title "実測データ" with points pt 7 ps 1.5, \
+(x/2500)**3 title "モデル: T = (N/2500)^3" with lines lw 2`{{execute}}
+
+`unset output`{{execute}}
+
+[データとモデルの比較]({{TRAFFIC_HOST1_80}}/plots/runtime_model.png)
 
 モデルがデータとよく一致していることがわかります。
 
@@ -35,17 +69,48 @@
 
 このモデルを使って、より大きなクラスターサイズでの実行時間を予測できます：
 
-`plot [1000:100000] "data/runtime.dat" using 1:2 title "実測データ" with points, \
-(x/2500)**3 title "モデル予測" with lines`{{execute}}
+`set output '/var/www/html/plots/runtime_prediction.png'`{{execute}}
+
+`set title "実行時間の予測"`{{execute}}
+
+`set grid`{{execute}}
+
+`plot [1000:100000][0.1:100000] \
+"data/runtime.dat" using 1:2 title "実測データ" with points pt 7 ps 1.5, \
+(x/2500)**3 title "モデル予測" with lines lw 2`{{execute}}
+
+`unset output`{{execute}}
+
+[実行時間の予測]({{TRAFFIC_HOST1_80}}/plots/runtime_prediction.png)
 
 N=100,000では約100,000秒（約28時間）かかることが予測されます。
+
+## ASCIIでの確認
+
+簡単に傾向を確認：
+
+`unset logscale`{{execute}}
+
+`set terminal dumb`{{execute}}
+
+`set logscale`{{execute}}
+
+`plot [1000:50000] "data/runtime.dat" using 1:2`{{execute}}
+
+べき乗則の特徴的な形状が確認できます。
+
+元の設定に戻します：
+
+`set terminal png size 800,600 font "Arial,14"`{{execute}}
+
+`unset logscale`{{execute}}
 
 ## グラフィカル分析の威力
 
 このように、グラフィカル分析により：
 
-1. **データの傾向を視覚的に把握**
-2. **適切なモデルを選択**
-3. **将来の値を予測**
+1. **データの傾向を視覚的に把握** - 急激な増加を確認
+2. **適切なモデルを選択** - 両対数プロットでべき乗則を発見
+3. **将来の値を予測** - モデルを外挿して予測
 
-することができます。
+することができます。適切なプロット方法（線形 vs 対数）の選択が、データの本質を理解する鍵となります。

--- a/lean-basic-of-gnuplot/scenario01/step4.md
+++ b/lean-basic-of-gnuplot/scenario01/step4.md
@@ -8,7 +8,9 @@
 
 `reset`{{execute}}
 
-軸ラベルを追加：
+`set terminal png size 800,600 font "Arial,14"`{{execute}}
+
+軸ラベルとタイトルを追加：
 
 `set xlabel "完走時間 [分]"`{{execute}}
 
@@ -16,7 +18,13 @@
 
 `set title "マラソン大会の完走時間分布"`{{execute}}
 
+`set output '/var/www/html/plots/marathon_labeled.png'`{{execute}}
+
 `plot "data/marathon.dat" using 1:2 with boxes title "2023年大会"`{{execute}}
+
+`unset output`{{execute}}
+
+[ラベル付きグラフを表示]({{TRAFFIC_HOST1_80}}/plots/marathon_labeled.png)
 
 ## グリッドの追加
 
@@ -24,24 +32,46 @@
 
 `set grid`{{execute}}
 
-`replot`{{execute}}
+`set output '/var/www/html/plots/marathon_grid.png'`{{execute}}
+
+`plot "data/marathon.dat" using 1:2 with boxes title "2023年大会"`{{execute}}
+
+`unset output`{{execute}}
+
+[グリッド付きグラフを表示]({{TRAFFIC_HOST1_80}}/plots/marathon_grid.png)
 
 ## 色とスタイルのカスタマイズ
 
-ボックスの色を変更：
+ボックスの色と幅を調整：
 
-`plot "data/marathon.dat" using 1:2 with boxes lc rgb "blue" title "2023年大会"`{{execute}}
+`set output '/var/www/html/plots/marathon_styled.png'`{{execute}}
 
-線幅を太くする：
+`set boxwidth 0.9 relative`{{execute}}
 
-`plot "data/marathon.dat" using 1:2 with boxes lw 2 lc rgb "dark-green" title "2023年大会"`{{execute}}
+`set style fill solid 0.8`{{execute}}
+
+`plot "data/marathon.dat" using 1:2 with boxes lc rgb "dark-green" title "2023年大会"`{{execute}}
+
+`unset output`{{execute}}
+
+[スタイル設定したグラフを表示]({{TRAFFIC_HOST1_80}}/plots/marathon_styled.png)
 
 ## 複数のデータセットの比較
 
 仮想的な前年のデータと比較するプロットを作成：
 
-`plot "data/marathon.dat" using 1:2 with boxes lc rgb "blue" title "2023年", \
-"data/marathon.dat" using 1:($2*0.9) with boxes lc rgb "red" title "2022年（仮想）"`{{execute}}
+`set output '/var/www/html/plots/marathon_compare.png'`{{execute}}
+
+`set style data boxes`{{execute}}
+
+`set style fill solid 0.5`{{execute}}
+
+`plot "data/marathon.dat" using 1:2 lc rgb "blue" title "2023年", \
+"data/marathon.dat" using 1:($2*0.9) lc rgb "red" title "2022年（仮想）"`{{execute}}
+
+`unset output`{{execute}}
+
+[比較グラフを表示]({{TRAFFIC_HOST1_80}}/plots/marathon_compare.png)
 
 ## DLAクラスターの可視化（ボーナス）
 
@@ -49,24 +79,66 @@
 
 `reset`{{execute}}
 
+`set terminal png size 600,600 font "Arial,14"`{{execute}}
+
+`set output '/var/www/html/plots/cluster.png'`{{execute}}
+
 `unset border`{{execute}}
 
 `unset xtics`{{execute}}
 
 `unset ytics`{{execute}}
 
+`unset key`{{execute}}
+
 `set size square`{{execute}}
 
-`plot "data/cluster_sample.dat" using 1:2 with points pt 7 ps 2`{{execute}}
+`plot "data/cluster_sample.dat" using 1:2 with points pt 7 ps 2 lc rgb "black"`{{execute}}
+
+`unset output`{{execute}}
+
+[DLAクラスターを表示]({{TRAFFIC_HOST1_80}}/plots/cluster.png)
 
 これは科学計算でよく使われる、装飾を最小限にしたプロットスタイルです。
+
+## 高品質な出力例
+
+最後に、出版品質のグラフを作成してみましょう：
+
+`reset`{{execute}}
+
+`set terminal png size 1000,700 font "Arial,16"`{{execute}}
+
+`set output '/var/www/html/plots/publication_quality.png'`{{execute}}
+
+`set title "マラソン大会完走時間分布の分析" font "Arial,20"`{{execute}}
+
+`set xlabel "完走時間 [分]" font "Arial,16"`{{execute}}
+
+`set ylabel "ランナー数 [人]" font "Arial,16"`{{execute}}
+
+`set grid`{{execute}}
+
+`set key top right font "Arial,14"`{{execute}}
+
+`set style data boxes`{{execute}}
+
+`set style fill solid 0.7`{{execute}}
+
+`set boxwidth 0.8 relative`{{execute}}
+
+`plot [120:450] "data/marathon.dat" using 1:2 lc rgb "#1f77b4" title "実測データ"`{{execute}}
+
+`unset output`{{execute}}
+
+[出版品質のグラフを表示]({{TRAFFIC_HOST1_80}}/plots/publication_quality.png)
 
 ## まとめ
 
 gnuplotでは：
 - `set` コマンドでグラフの外観をカスタマイズ
 - 軸ラベル、タイトル、凡例で文脈を提供
-- 色、線幅、点の形状で視覚的な差別化
+- 色、線幅、塗りつぶしで視覚的な差別化
 - 目的に応じて装飾の量を調整
 
 これらの機能を使いこなすことで、**データの洞察を効果的に伝える**グラフを作成できます。


### PR DESCRIPTION
## Summary
- Fix the Qt display error in Killercoda's terminal-only environment
- Implement web-based solution for viewing gnuplot graphs

## Problem
Killercoda provides a terminal-only environment without X11 display server, causing the error:
```
qt.qpa.xcb: could not connect to display
```

## Solution
Implemented a web-based approach using Apache2 to serve gnuplot output as PNG images:

1. **Apache2 Integration**:
   - Install and configure Apache2 in setup.sh
   - Create `/var/www/html/plots/` directory for graph output
   - Serve images via HTTP

2. **Updated All Plot Commands**:
   - Set PNG terminal: `set terminal png size 800,600 font "Arial,14"`
   - Output to web directory: `set output '/var/www/html/plots/filename.png'`
   - View via: `{{TRAFFIC_HOST1_80}}/plots/filename.png`

3. **Alternative Display Method**:
   - ASCII terminal (`set terminal dumb`) for quick terminal viewing
   - Provides both high-quality PNG and quick ASCII options

## Changes
- Modified `setup.sh`: Install Apache2, create output directory
- Updated `step1.md`: Basic plots with web display
- Updated `step2.md`: Marathon data analysis with web graphs
- Updated `step3.md`: Runtime prediction with multiple output formats
- Updated `step4.md`: Graph customization and publication quality output

## Test plan
- [ ] Verify Apache2 starts correctly in Killercoda
- [ ] Confirm PNG files are generated in `/var/www/html/plots/`
- [ ] Test all {{TRAFFIC_HOST1_80}} links display graphs
- [ ] Verify ASCII terminal (dumb) works as fallback
- [ ] Check all gnuplot commands execute without errors