### PR TITLE
Fix graph URL paths to include /plots/ prefix

### DIFF
--- a/lean-basic-of-gnuplot/scenario01/step1.md
+++ b/lean-basic-of-gnuplot/scenario01/step1.md
@@ -64,7 +64,7 @@ gnuplotを一旦終了します：
 
 Webブラウザでグラフを表示できます：
 
-[正弦波のグラフを表示]({{TRAFFIC_HOST1_8080}}/sin_plot.png)
+[正弦波のグラフを表示]({{TRAFFIC_HOST1_8080}}/plots/sin_plot.png)
 
 ---
 
@@ -134,10 +134,10 @@ gnuplotを終了します：
 
 以下のリンクから各グラフを表示できます：
 
-- [正弦波のグラフ]({{TRAFFIC_HOST1_8080}}/sin_plot.png)
-- [正弦波と余弦波]({{TRAFFIC_HOST1_8080}}/sin_cos_plot.png)
-- [スタイルの異なるグラフ]({{TRAFFIC_HOST1_8080}}/style_plot.png)
-- [範囲指定したグラフ]({{TRAFFIC_HOST1_8080}}/range_plot.png)
+- [正弦波のグラフ]({{TRAFFIC_HOST1_8080}}/plots/sin_plot.png)
+- [正弦波と余弦波]({{TRAFFIC_HOST1_8080}}/plots/sin_cos_plot.png)
+- [スタイルの異なるグラフ]({{TRAFFIC_HOST1_8080}}/plots/style_plot.png)
+- [範囲指定したグラフ]({{TRAFFIC_HOST1_8080}}/plots/range_plot.png)
 
 ---
 

--- a/lean-basic-of-gnuplot/scenario01/step2.md
+++ b/lean-basic-of-gnuplot/scenario01/step2.md
@@ -32,7 +32,7 @@ gnuplotを再起動してデータをプロットします：
 
 `unset output`{{execute}}
 
-[マラソンデータの全体像を表示]({{TRAFFIC_HOST1_8080}}/marathon_full.png)
+[マラソンデータの全体像を表示]({{TRAFFIC_HOST1_8080}}/plots/marathon_full.png)
 
 ## データの分析
 
@@ -70,7 +70,7 @@ gnuplotを再起動してデータをプロットします：
 
 `unset output`{{execute}}
 
-[早い時間帯の詳細を表示]({{TRAFFIC_HOST1_8080}}/marathon_zoom.png)
+[早い時間帯の詳細を表示]({{TRAFFIC_HOST1_8080}}/plots/marathon_zoom.png)
 
 ## ASCIIでの簡易確認
 

--- a/lean-basic-of-gnuplot/scenario01/step3.md
+++ b/lean-basic-of-gnuplot/scenario01/step3.md
@@ -22,7 +22,7 @@
 
 `unset output`{{execute}}
 
-[実行時間データ（線形スケール）]({{TRAFFIC_HOST1_8080}}/runtime_linear.png)
+[実行時間データ（線形スケール）]({{TRAFFIC_HOST1_8080}}/plots/runtime_linear.png)
 
 このグラフでは、クラスターサイズが大きくなるにつれて実行時間が急激に増加していることがわかります。
 
@@ -44,7 +44,7 @@
 
 `unset output`{{execute}}
 
-[実行時間データ（両対数スケール）]({{TRAFFIC_HOST1_8080}}/runtime_loglog.png)
+[実行時間データ（両対数スケール）]({{TRAFFIC_HOST1_8080}}/plots/runtime_loglog.png)
 
 両対数プロットで直線になることから、実行時間がべき乗則に従うことがわかります。
 
@@ -61,7 +61,7 @@
 
 `unset output`{{execute}}
 
-[データとモデルの比較]({{TRAFFIC_HOST1_8080}}/runtime_model.png)
+[データとモデルの比較]({{TRAFFIC_HOST1_8080}}/plots/runtime_model.png)
 
 モデルがデータとよく一致していることがわかります。
 
@@ -81,7 +81,7 @@
 
 `unset output`{{execute}}
 
-[実行時間の予測]({{TRAFFIC_HOST1_8080}}/runtime_prediction.png)
+[実行時間の予測]({{TRAFFIC_HOST1_8080}}/plots/runtime_prediction.png)
 
 N=100,000では約100,000秒（約28時間）かかることが予測されます。
 

--- a/lean-basic-of-gnuplot/scenario01/step4.md
+++ b/lean-basic-of-gnuplot/scenario01/step4.md
@@ -24,7 +24,7 @@
 
 `unset output`{{execute}}
 
-[ラベル付きグラフを表示]({{TRAFFIC_HOST1_8080}}/marathon_labeled.png)
+[ラベル付きグラフを表示]({{TRAFFIC_HOST1_8080}}/plots/marathon_labeled.png)
 
 ## グリッドの追加
 
@@ -38,7 +38,7 @@
 
 `unset output`{{execute}}
 
-[グリッド付きグラフを表示]({{TRAFFIC_HOST1_8080}}/marathon_grid.png)
+[グリッド付きグラフを表示]({{TRAFFIC_HOST1_8080}}/plots/marathon_grid.png)
 
 ## 色とスタイルのカスタマイズ
 
@@ -54,7 +54,7 @@
 
 `unset output`{{execute}}
 
-[スタイル設定したグラフを表示]({{TRAFFIC_HOST1_8080}}/marathon_styled.png)
+[スタイル設定したグラフを表示]({{TRAFFIC_HOST1_8080}}/plots/marathon_styled.png)
 
 ## 複数のデータセットの比較
 
@@ -71,7 +71,7 @@
 
 `unset output`{{execute}}
 
-[比較グラフを表示]({{TRAFFIC_HOST1_8080}}/marathon_compare.png)
+[比較グラフを表示]({{TRAFFIC_HOST1_8080}}/plots/marathon_compare.png)
 
 ## DLAクラスターの可視化（ボーナス）
 
@@ -97,7 +97,7 @@
 
 `unset output`{{execute}}
 
-[DLAクラスターを表示]({{TRAFFIC_HOST1_8080}}/cluster.png)
+[DLAクラスターを表示]({{TRAFFIC_HOST1_8080}}/plots/cluster.png)
 
 これは科学計算でよく使われる、装飾を最小限にしたプロットスタイルです。
 
@@ -131,7 +131,7 @@
 
 `unset output`{{execute}}
 
-[出版品質のグラフを表示]({{TRAFFIC_HOST1_8080}}/publication_quality.png)
+[出版品質のグラフを表示]({{TRAFFIC_HOST1_8080}}/plots/publication_quality.png)
 
 ## まとめ
 


### PR DESCRIPTION
## Summary
Fixed incorrect graph URLs that were causing 404 errors when trying to view generated plots.

## Issue
User reported getting 404 error:
```
Wrong URL: https://xxx.killercoda.com/sin_plot.png
```

## Root Cause
- Python HTTP server is started from `/root/work/` directory
- Graphs are saved in `/root/work/plots/` subdirectory  
- URLs were missing the `/plots/` path component

## Solution
Updated all graph URLs from:
```
{{TRAFFIC_HOST1_8080}}/filename.png
```

To:
```
{{TRAFFIC_HOST1_8080}}/plots/filename.png
```

## Changes
- Fixed 5 URLs in step1.md
- Fixed 2 URLs in step2.md
- Fixed 4 URLs in step3.md
- Fixed 6 URLs in step4.md
- **Total: 17 URLs fixed**

## Testing
User confirmed the issue with execution log showing:
- Correct file creation: `/root/work/plots/sin_plot.png`
- Incorrect URL attempted: `/sin_plot.png`

This fix ensures all graph links work correctly.